### PR TITLE
Supprimer l'override du form_row widget

### DIFF
--- a/app/Resources/views/Templates/Form/Widgets/default_widgets.html.twig
+++ b/app/Resources/views/Templates/Form/Widgets/default_widgets.html.twig
@@ -1,10 +1,3 @@
-
-{% block form_row %}
-    {{ block('form_label') }}
-    {{ block('form_widget_simple') }}
-    {{ block('form_errors') }}
-{% endblock %}
-
 {# simple widget #}
 {% block form_widget_simple -%}
     <div class="field">


### PR DESCRIPTION
Hello,

J'ai essayé pendant de longues heures de faire fonctionner des champs personnalisés dans mes vues sans succès... et j'en ai enfin trouvé la cause : un override des block "form_row" dans le fichier default_widgets.html.twig.

Est-ce que cet override avait un but précis ? Car de ce que j'ai pu constaté il m'empêche d'utiliser des blocs personnalisés et me force à utiliser des champs de texte.
J'ai aussi remarqué qu'après l'avoir enlevé le type 'datepicker' se générait correctement dans notre bundle alors qu'avant il ne sortait qu'un champ de texte basique.