### PR TITLE
Fix checkbox status in Form Widget

### DIFF
--- a/app/Resources/views/Templates/Form/Widgets/default_widgets.html.twig
+++ b/app/Resources/views/Templates/Form/Widgets/default_widgets.html.twig
@@ -87,7 +87,7 @@
 {# checkbox #}
 {% block checkbox_widget -%}
     <div class="ui checkbox">
-        <input {{ block('widget_attributes') }} type="checkbox">
+        <input {{ block('widget_attributes') }} {% if value is defined %} value="{{value}}" {% endif %} {% if checked %} checked="checked" {% endif %} type="checkbox">
         {{ block('form_label') }}
     </div>
 {%- endblock checkbox_widget %}


### PR DESCRIPTION
Petit bug, le statut des checkbox ne s'affiche pas dans les formulaires, elles sont toujours "unchecked" quelque soit la valeur stockée dans l'Entity que l'on modifie.

Je l'ai mis en pull request car je suis pas certain des conséquences... Normalement ça ne devrait rien changer ;-)